### PR TITLE
fix: migrate Google Analytics to Next.js third-parties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@next/third-parties": "^15.1.6",
         "@payloadcms/db-postgres": "latest",
         "@payloadcms/email-resend": "latest",
         "@payloadcms/live-preview-react": "latest",
@@ -3538,6 +3539,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.1.6.tgz",
+      "integrity": "sha512-F0uemUqFwD3lLx5SrWXYRe9dZvMVkO0rFuMnvLiPBcagxNc23Ufl5cNXEm4Yuo8O1Mu8dgh+VjExMz1Td4vBew==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -14814,6 +14828,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start"
   },
   "dependencies": {
+    "@next/third-parties": "^15.1.6",
     "@payloadcms/db-postgres": "latest",
     "@payloadcms/email-resend": "latest",
     "@payloadcms/live-preview-react": "latest",

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import Script from 'next/script'
+import { GoogleTagManager } from '@next/third-parties/google'
 
 import { GeistMono } from 'geist/font/mono'
 import { GeistSans } from 'geist/font/sans'
@@ -25,26 +25,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html className={cn(GeistSans.variable, GeistMono.variable)} lang="zh" suppressHydrationWarning>
       <head>
         <InitTheme />
+        <GoogleTagManager gtmId="G-F51E8ZGYWJ" />
         <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
-
-        {/* Google Analytics */}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-F51E8ZGYWJ"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-
-            gtag('config', 'G-F51E8ZGYWJ');
-          `}
-        </Script>
       </head>
       <body>
         <Providers>


### PR DESCRIPTION
- Replaced manual Google Tag Manager script with @next/third-parties GoogleTagManager component
- Simplified analytics integration in the root layout
- Updated package.json and package-lock.json to include @next/third-parties dependency